### PR TITLE
V0.3.0.0

### DIFF
--- a/KeepNames.cs
+++ b/KeepNames.cs
@@ -7,42 +7,25 @@ using IL.Terraria;
 using MonoMod.Cil;
 using static Mono.Cecil.Cil.OpCodes;
 using Mono.Cecil.Cil;
+using log4net.Repository.Hierarchy;
+using log4net.Core;
 
 namespace KeepNames {
 	public class KeepNames : Mod {
 		internal static List<int> blacklist = new List<int> { };
 		internal static List<name> names = new List<name> { };
-		public static string debugBlacklist() {
-            return string.Join(", ", GetInstance<nameConfigServer>().manualBlackList);
-		}
 		internal static bool _patchedGame;
 		public static bool patchedGame { get; }
-		/* (20,4)-(20,63) main.cs */
-	/* 0x00000000 02           */ //IL_0000: ldarg.0
-	/* 0x00000001 28????????   */ //IL_0001: call      string [KeepNames]KeepNames.KeepNames::getSavedName(int32)
-	/* 0x00000006 0A           */ //IL_0006: stloc.0
-	/* (21,4)-(21,23) main.cs */
-	/* 0x00000007 06           */ //IL_0007: ldloc.0
-	/* 0x00000008 2C02         */ //IL_0008: brfalse.s IL_000C
-
-	/* (21,24)-(21,39) main.cs */
-	/* 0x0000000A 06           */ //IL_000A: ldloc.0
-	/* 0x0000000B 2A           */ //IL_000B: ret
 
         public override void Load() {
-            base.Load();
             NPC.getNewNPCName += NPC_getNewNPCName;
         }
 
         private void NPC_getNewNPCName(ILContext il) {
 			ILCursor c = new ILCursor(il);
-			/*if (!c.TryGotoNext(i => i.MatchLdcI4(178))) { // We look for the beginning of the function
-				_patchedGame = false; // Fall back to PreAI() changing
-				return; // Patch unable to be applied
-			}*/
+			
 			try {
 				System.Reflection.MethodInfo method = typeof(KeepNames).GetMethod(nameof(getSavedName));
-				//System.Reflection.MethodBase inject = method.MakeGenericMethod(typeof(int));
 
 				ILLabel label = il.DefineLabel();
 				c.Emit(Ldarg_0);
@@ -69,8 +52,8 @@ namespace KeepNames {
 			if (!blacklist.Contains(id)) blacklist.Add(id);
 			int i = names.FindIndex(obj => obj.id == id);
 			if(i!=-1) { names.RemoveAt(i); }
-
-        }
+			
+		}
 		/// <summary>
 		/// Manually set an entities name for later use.
 		/// Does not update current NPCs
@@ -135,7 +118,7 @@ namespace KeepNames {
 					case "getSavedName": {
 							int? id = args[1] as int?;
 							if (id == null) { Logger.Error("Second argument of getSavedName must be an int."); return false; }
-							getSavedName((int)id);
+                            _ = KeepNames.getSavedName((int)id);
 							return true;
 						}
 					default:

--- a/KeepNames.cs
+++ b/KeepNames.cs
@@ -9,13 +9,15 @@ using static Mono.Cecil.Cil.OpCodes;
 using Mono.Cecil.Cil;
 using log4net.Repository.Hierarchy;
 using log4net.Core;
+using Terraria.ID;
 
 namespace KeepNames {
 	public class KeepNames : Mod {
 		internal static List<int> blacklist = new List<int> { };
+		internal static List<int> considerAsTownNPCs = new List<int> { NPCID.SkeletonMerchant };
 		internal static List<name> names = new List<name> { };
 		internal static bool _patchedGame;
-		public static bool patchedGame { get; }
+		public static bool patchedGame { get { return _patchedGame; } }
 
         public override void Load() {
             NPC.getNewNPCName += NPC_getNewNPCName;

--- a/KeepNames.cs
+++ b/KeepNames.cs
@@ -49,6 +49,8 @@ namespace KeepNames {
         /// </summary>
         /// <param name="id">The NPCID of the NPC to blacklist</param>
         public static void blacklistNPC(int id) {
+			//exit if we are not either the host or in singleplayer
+			if (Terraria.Main.netMode == Terraria.ID.NetmodeID.MultiplayerClient || Terraria.Main.dedServ) return;
 			if (!blacklist.Contains(id)) blacklist.Add(id);
 			int i = names.FindIndex(obj => obj.id == id);
 			if(i!=-1) { names.RemoveAt(i); }
@@ -61,6 +63,8 @@ namespace KeepNames {
 		/// <param name="id">The NPCID of the NPC</param>
 		/// <param name="newName">The new name to set</param>
 		public static void setName(int id, string newName) {
+			//exit if we are not either the host or in singleplayer
+			if (Terraria.Main.netMode == Terraria.ID.NetmodeID.MultiplayerClient || Terraria.Main.dedServ) return;
 			if (blacklist.Contains(id)) return;
 			int i = names.FindIndex(obj => obj.id == id);
 			if(i==-1) {
@@ -75,6 +79,8 @@ namespace KeepNames {
 		/// </summary>
 		/// <param name="id">The NPCID of the NPC</param>
 		public static string getSavedName(int id) {
+			//exit if we are not either the host or in singleplayer
+			if (Terraria.Main.netMode == Terraria.ID.NetmodeID.MultiplayerClient || Terraria.Main.dedServ) return null;
 			if (blacklist.Contains(id) || GetInstance<nameConfigServer>().manualBlackList.FindIndex(b => b.Type == id) != -1) return null;
 			int i = names.FindIndex(obj => obj.id == id);
 			if (i == -1 || names[i].givenName == "") return null;

--- a/KeepNames.cs
+++ b/KeepNames.cs
@@ -7,8 +7,6 @@ using IL.Terraria;
 using MonoMod.Cil;
 using static Mono.Cecil.Cil.OpCodes;
 using Mono.Cecil.Cil;
-using log4net.Repository.Hierarchy;
-using log4net.Core;
 using Terraria.ID;
 
 namespace KeepNames {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Persistant Names](icon.png)
+<img src="icon.png" alt="Logo"
+	title="Logo" width="150" style="image-rendering: pixelated;"/>
 # Persistant Names
 
 Persistant Names will make it so your NPCs will always keep the same names- even if they die and respawn!

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="icon.png" alt="Logo"
 	title="Logo" width="150" style="image-rendering: pixelated;"/>
 # Persistant Names
-
+[Talk to us on Discord](https://discord.gg/ET9mGwH)  
 Persistant Names will make it so your NPCs will always keep the same names- even if they die and respawn!
 
 ## Your Town will remain!

--- a/description.txt
+++ b/description.txt
@@ -1,6 +1,9 @@
 Persistent Names will make it so your NPCs will always keep the same names- even if they die and respawn!
 See documentation on exempting your mod on the homepage. Submit bugs on Github Issues.
 
+Discord: https://discord.gg/ET9mGwH
+Github: https://github.com/RonanFinley/PersistentNames
+
 Verson 0.2.0.1
 - Fixed all instances of misspelled "Persistent"
 

--- a/description.txt
+++ b/description.txt
@@ -4,12 +4,8 @@ See documentation on exempting your mod on the homepage. Submit bugs on Github I
 Discord: https://discord.gg/ET9mGwH
 Github: https://github.com/RonanFinley/PersistentNames
 
-Verson 0.2.0.1
-- Fixed all instances of misspelled "Persistent"
-
-Version 0.2.0.0 Change Log
-- Old Testing Code Removed
-- Now reapplies blacklist when loadign and saving files
-- Added Mod.Call Support
-- Added Manually Disabling NPCs (Inside Mod Configuration)
-- Fixed bug where empty strings would be saved. These will be fixed automatically upon next load.
+Version 0.3.0.0
+- Names will now appear in Arrival Messages
+  - If there is an error, Persistent Names will fall back to the origional method
+- Added a Discord Server (Above)
+- Fixed potential Multiplayer Problems

--- a/interceptNames.cs
+++ b/interceptNames.cs
@@ -1,25 +1,26 @@
-﻿using System;
-using Terraria;
+﻿using Terraria;
 using Terraria.ModLoader;
 using static Terraria.ModLoader.ModContent;
 
 namespace KeepNames {
     class interceptNames : GlobalNPC {
         public override bool PreAI(NPC npc) {
-            if (!KeepNames.patchedGame
-                && !KeepNames.blacklist.Contains(npc.type)
-                && npc.townNPC
+            if (!KeepNames.blacklist.Contains(npc.type)
+                && ( npc.townNPC || KeepNames.considerAsTownNPCs.Contains(npc.type) )
                 && GetInstance<nameConfigServer>().manualBlackList.FindIndex(b => b.Type == npc.type) == -1
                 //exit if we are not either the host or in singleplayer
-                && !(Terraria.Main.netMode == Terraria.ID.NetmodeID.MultiplayerClient && !Terraria.Main.dedServ)) {
-                int i = KeepNames.names.FindIndex(obj => obj.id == npc.type);
-                if (i != -1) {
-                    npc.GivenName = KeepNames.names[i].givenName;
-                }
-                else if (npc.townNPC && !KeepNames.blacklist.Contains(npc.type) && npc.GivenName!="") {
+                && !(Main.netMode != Terraria.ID.NetmodeID.SinglePlayer && !Main.dedServ)) {
+                if(!KeepNames.patchedGame) {
+                    int i = KeepNames.names.FindIndex(obj => obj.id == npc.type);
+                    if (i != -1) {
+                        npc.GivenName = KeepNames.names[i].givenName;
+                    }
+                } else if ( npc.GivenName != "" ) {
                     KeepNames.setName(npc.type, npc.GivenName);
                 }
+
             }
+            
             return base.PreAI(npc);
         }
     }

--- a/interceptNames.cs
+++ b/interceptNames.cs
@@ -5,17 +5,11 @@ using static Terraria.ModLoader.ModContent;
 
 namespace KeepNames {
     class interceptNames : GlobalNPC {
-        public override void SetDefaults(NPC npc) {
-            if (!KeepNames.blacklist.Contains(npc.type) && npc.townNPC && GetInstance<nameConfigServer>().manualBlackList.FindIndex(b => b.Type == npc.type) == -1) {
-                int i = KeepNames.names.FindIndex(obj => obj.id == npc.type);
-                if (i != -1) {
-                    npc.GivenName = KeepNames.names[i].givenName;
-                }
-            }
-            base.SetDefaults(npc);
-        }
         public override bool PreAI(NPC npc) {
-            if (!KeepNames.blacklist.Contains(npc.type) && npc.townNPC && GetInstance<nameConfigServer>().manualBlackList.FindIndex(b => b.Type == npc.type)==-1) {
+            if (!KeepNames.patchedGame
+                && !KeepNames.blacklist.Contains(npc.type)
+                && npc.townNPC
+                && GetInstance<nameConfigServer>().manualBlackList.FindIndex(b => b.Type == npc.type) == -1) {
                 int i = KeepNames.names.FindIndex(obj => obj.id == npc.type);
                 if (i != -1) {
                     npc.GivenName = KeepNames.names[i].givenName;

--- a/interceptNames.cs
+++ b/interceptNames.cs
@@ -9,7 +9,9 @@ namespace KeepNames {
             if (!KeepNames.patchedGame
                 && !KeepNames.blacklist.Contains(npc.type)
                 && npc.townNPC
-                && GetInstance<nameConfigServer>().manualBlackList.FindIndex(b => b.Type == npc.type) == -1) {
+                && GetInstance<nameConfigServer>().manualBlackList.FindIndex(b => b.Type == npc.type) == -1
+                //exit if we are not either the host or in singleplayer
+                && !(Terraria.Main.netMode == Terraria.ID.NetmodeID.MultiplayerClient && !Terraria.Main.dedServ)) {
                 int i = KeepNames.names.FindIndex(obj => obj.id == npc.type);
                 if (i != -1) {
                     npc.GivenName = KeepNames.names[i].givenName;


### PR DESCRIPTION
* Now hooks `getNewNPCName(int type)` to change name before anything else sees it (Resolves #1)
* Use old method as patch fallback
* Fixed potential Multiplayer Problems